### PR TITLE
Update composer.json to be compatible with PHP 8.2 and PHP 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         }
     ],
     "require": {
-        "php": "7.4|8.0.*|8.1.*",
+        "php": "8.1.*|8.2.*|8.3.*",
         "parsica-php/parsica": "^0.8.1",
-        "symfony/property-access": "^5.4|^6.0"
+        "symfony/property-access": "^5.4|^6.4|^7.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
Thank you for your developing!

I would like to allow `composer install` to run when using PHP 8.2 and PHP 8.3.
This PR updates composer.json to be compatible with PHP 8.2 and PHP 8.3 and removes support for PHP 8.0 or lower because PhpDocumentor requires PHP 8.1 or higher to run.

Would you please consider this PR?

Thank you.